### PR TITLE
replace requestAnimationFrame with raf

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   "devDependencies": {
     "tape": "~2.1.0",
     "crel": "^1.1.1"
+  },
+  "dependencies": {
+    "raf": "^3.1.0"
   }
 }

--- a/scrollIntoView.js
+++ b/scrollIntoView.js
@@ -1,3 +1,5 @@
+var raf = require('raf');
+
 function setElementScroll(element, x, y){
     if(element === window){
         element.scrollTo(x, y);
@@ -44,7 +46,7 @@ function getTargetScrollLocation(target, parent){
 }
 
 function animate(parent){
-    requestAnimationFrame(function(){
+    raf(function(){
         var scrollSettings = parent._scrollSettings;
         if(!scrollSettings){
             return;

--- a/scrollIntoView.js
+++ b/scrollIntoView.js
@@ -85,7 +85,6 @@ module.exports = function(target){
             parent.scrollWidth !== parent.clientWidth
         ){
             transitionScrollTo(target, parent);
-            return;
         }
 
         parent = parent.parentElement;

--- a/scrollIntoView.js
+++ b/scrollIntoView.js
@@ -85,6 +85,7 @@ module.exports = function(target){
             parent.scrollWidth !== parent.clientWidth
         ){
             transitionScrollTo(target, parent);
+            return;
         }
 
         parent = parent.parentElement;


### PR DESCRIPTION
To support older browsers such as IE9 and phantomjs 1.9, we need a polyfill for requestAnimationFrame. raf has worked well for us so far.