### PR TITLE
Body height less than scroll height

### DIFF
--- a/scrollIntoView.js
+++ b/scrollIntoView.js
@@ -21,8 +21,8 @@ function getTargetScrollLocation(target, parent){
     if(parent === window){
         x = targetPosition.left + window.scrollX - window.innerWidth / 2 + Math.min(targetPosition.width, window.innerWidth) / 2;
         y = targetPosition.top + window.scrollY - window.innerHeight / 2 + Math.min(targetPosition.height, window.innerHeight) / 2;
-        x = Math.max(Math.min(x, document.body.clientWidth - window.innerWidth / 2), 0);
-        y = Math.max(Math.min(y, document.body.clientHeight - window.innerHeight / 2), 0);
+        x = Math.max(Math.min(x, document.body.scrollWidth - window.innerWidth / 2), 0);
+        y = Math.max(Math.min(y, document.body.scrollHeight- window.innerHeight / 2), 0);
         differenceX = x - window.scrollX;
         differenceY = y - window.scrollY;
     }else{

--- a/test/test.js
+++ b/test/test.js
@@ -164,3 +164,34 @@ test('invalid target', function(t) {
         );
     });
 });
+
+test('body height less than scroll height', function(t) {
+    var target;
+
+    t.plan(1);
+
+    queue(function(next){
+
+        crel(document.documentElement, {'style': 'height: 100%'},
+            crel(document.body, {'style':'height: 100%'},
+                crel('div', {'style':'position:relative; height:5000px;'},
+                    crel('div', {'style':'position:relative; font-size:20em; display:inline-block'},
+                        target = crel('span', {'style':'position:absolute; top:75%; left: 75%; box-shadow: 0 0 10px 10px red;'}),
+                        crel('div', {style: 'white-space:nowrap;'}, 'TEXT-AND-THAT-TO-MAKE-STUFF-HELA-WIDE'),
+                        crel('div', {style: 'white-space:nowrap;'}, 'TEXT-AND-THAT-TO-MAKE-STUFF-HELA-WIDE'),
+                        crel('div', {style: 'white-space:nowrap;'}, 'TEXT-AND-THAT-TO-MAKE-STUFF-HELA-WIDE')
+                    )
+                )
+            )
+        );
+
+        scrollIntoView(target, function(){
+            t.ok(
+                target.getBoundingClientRect().top < window.innerHeight &&
+                target.getBoundingClientRect().left < window.innerWidth,
+                'target was in view'
+            );
+            next();
+        });
+    });
+});


### PR DESCRIPTION
Here's a failing test followed by a fix (that appears to break no other tests) for a situation I've encountered in the wild.

When the `html` and `body` elements have a height of "100%" but the content overflows that, the last parent scroll operation calculates the scroll position incorrectly.

I'm not familiar with your testing setup, so I don't know if there's something obvious I should be doing to reset the style of the `html` element.

Let me know anything I can do to clean this up.

Thanks!