### PR TITLE
Fixed logical check for validTarget

### DIFF
--- a/scrollIntoView.js
+++ b/scrollIntoView.js
@@ -145,19 +145,21 @@ module.exports = function(target, settings, callback){
             // If there is a validTarget function, check it.
             (settings.validTarget ? settings.validTarget(parent, parents) : true) &&
 
-            // Else if window
-            parent === window ||
-
-            // Else...
             (
-                /// check if scrollable
-                (
-                    parent.scrollHeight !== parent.clientHeight ||
-                    parent.scrollWidth !== parent.clientWidth
-                ) &&
+                // Else if window
+                parent === window ||
 
-                // And not hidden.
-                getComputedStyle(parent).overflow !== 'hidden'
+                // Else...
+                (
+                    /// check if scrollable
+                    (
+                        parent.scrollHeight !== parent.clientHeight ||
+                        parent.scrollWidth !== parent.clientWidth
+                    ) &&
+
+                    // And not hidden.
+                    getComputedStyle(parent).overflow !== 'hidden'
+                )
             )
         ){
             parents++;


### PR DESCRIPTION
Hey @KoryNunn,

I was trying to flag some targets as not valid for scrolling using the validTarget setting function but even when `validTarget` I returned `false`, the logical check in the exported function always executed as `true` since according to the current implementation:

`(false) && false || true -> ((false) && false) || true -> false || true -> true.`

Not sure if that is what is desired? If not, I created a PR that should fix this. Let me know what you think.

Cheers 