### PR TITLE
Scroll to screen offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ scrollIntoView(someElement, {
     align:{
         top: 0 to 1, default 0.5 (center)
         left: 0 to 1, default 0.5 (center)
+        topOffset: 0 to 1, default 0 (top) e.g. -(1/window.innerHeight*40) for a 40 pixel offset (appbar height) from the top
+        leftOffset: 0 to 1, default 0 (left)
     }
 });
 ```

--- a/scrollIntoView.js
+++ b/scrollIntoView.js
@@ -28,6 +28,7 @@ function getTargetScrollLocation(target, parent, align){
         y = targetPosition.top + window.pageYOffset - window.innerHeight * topScalar + Math.min(targetPosition.height, window.innerHeight) * topScalar;
         x = Math.max(Math.min(x, document.body.scrollWidth - window.innerWidth * leftScalar), 0);
         y = Math.max(Math.min(y, document.body.scrollHeight- window.innerHeight * topScalar), 0);
+        y -= 40;
         differenceX = x - window.pageXOffset;
         differenceY = y - window.pageYOffset;
     }else{
@@ -38,6 +39,7 @@ function getTargetScrollLocation(target, parent, align){
         y = offsetTop + (targetPosition.height * topScalar) - parent.clientHeight * topScalar;
         x = Math.max(Math.min(x, parent.scrollWidth - parent.clientWidth), 0);
         y = Math.max(Math.min(y, parent.scrollHeight - parent.clientHeight), 0);
+        y -= 40;
         differenceX = x - parent.scrollLeft;
         differenceY = y - parent.scrollTop;
     }

--- a/scrollIntoView.js
+++ b/scrollIntoView.js
@@ -30,8 +30,8 @@ function getTargetScrollLocation(target, parent, align){
         y = targetPosition.top + window.pageYOffset - window.innerHeight * topScalar + Math.min(targetPosition.height, window.innerHeight) * topScalar;
         x = Math.max(Math.min(x, document.body.scrollWidth - window.innerWidth * leftScalar), 0);
         y = Math.max(Math.min(y, document.body.scrollHeight- window.innerHeight * topScalar), 0);
-        x += leftAlignOffset;
-        y += topAlignOffset;
+        x += leftAlignOffset * window.innerWidth;
+        y += topAlignOffset * window.innerHeight;
         differenceX = x - window.pageXOffset;
         differenceY = y - window.pageYOffset;
     }else{
@@ -42,8 +42,8 @@ function getTargetScrollLocation(target, parent, align){
         y = offsetTop + (targetPosition.height * topScalar) - parent.clientHeight * topScalar;
         x = Math.max(Math.min(x, parent.scrollWidth - parent.clientWidth), 0);
         y = Math.max(Math.min(y, parent.scrollHeight - parent.clientHeight), 0);
-        x += leftAlignOffset;
-        y += topAlignOffset;
+        x += leftAlignOffset * window.innerWidth;
+        y += topAlignOffset * window.innerHeight;
         differenceX = x - parent.scrollLeft;
         differenceY = y - parent.scrollTop;
     }

--- a/scrollIntoView.js
+++ b/scrollIntoView.js
@@ -21,14 +21,17 @@ function getTargetScrollLocation(target, parent, align){
         leftAlign = align && align.left != null ? align.left : 0.5,
         topAlign = align && align.top != null ? align.top : 0.5,
         leftScalar = leftAlign,
-        topScalar = topAlign;
+        topScalar = topAlign,
+        leftAlignOffset = align && align.leftOffset != null ? align.leftOffset : 0,
+        topAlignOffset = align && align.topOffset != null ? align.topOffset : 0;
 
     if(parent === window){
         x = targetPosition.left + window.pageXOffset - window.innerWidth * leftScalar + Math.min(targetPosition.width, window.innerWidth) * leftScalar;
         y = targetPosition.top + window.pageYOffset - window.innerHeight * topScalar + Math.min(targetPosition.height, window.innerHeight) * topScalar;
         x = Math.max(Math.min(x, document.body.scrollWidth - window.innerWidth * leftScalar), 0);
         y = Math.max(Math.min(y, document.body.scrollHeight- window.innerHeight * topScalar), 0);
-        y -= 40;
+        x += leftAlignOffset;
+        y += topAlignOffset;
         differenceX = x - window.pageXOffset;
         differenceY = y - window.pageYOffset;
     }else{
@@ -39,7 +42,8 @@ function getTargetScrollLocation(target, parent, align){
         y = offsetTop + (targetPosition.height * topScalar) - parent.clientHeight * topScalar;
         x = Math.max(Math.min(x, parent.scrollWidth - parent.clientWidth), 0);
         y = Math.max(Math.min(y, parent.scrollHeight - parent.clientHeight), 0);
-        y -= 40;
+        x += leftAlignOffset;
+        y += topAlignOffset;
         differenceX = x - parent.scrollLeft;
         differenceY = y - parent.scrollTop;
     }


### PR DESCRIPTION
This would allow me to always scroll a section to just below my fixed appbar as mentioned in issue https://github.com/KoryNunn/scroll-into-view/issues/25 with the code below

```
scrollIntoView(target, { align: {
   top: 0,
   topOffset: -(1 / window.innerHeight * appBarHeight),
}})
```