### PR TITLE
rewrite arrow function to an anonymous function

### DIFF
--- a/scrollIntoView.js
+++ b/scrollIntoView.js
@@ -272,5 +272,7 @@ module.exports = function(target, settings, callback){
         }
     }
 
-    return scrollingElements.reduce((cancel, parent, index) => transitionScrollTo(target, parent, settings, scrollingElements[index + 1], done), null);
+    return scrollingElements.reduce(function(cancel, parent, index) {
+        return transitionScrollTo(target, parent, settings, scrollingElements[index + 1], done);
+    }, null);
 };


### PR DESCRIPTION
## Description 

Replace arrow-function (ES6 syntax) with an anonymous function.

fixes #97 